### PR TITLE
Add API key to client options

### DIFF
--- a/samples/koa/app.ts
+++ b/samples/koa/app.ts
@@ -8,19 +8,15 @@ import { Client } from "@umbraco/headless-client";
 
 const app = new Koa();
 const client = new Client({
-  projectAlias: process.env.UMBRACO__PROJECTALIAS || require('./package.json').umbraco.projectAlias
+  projectAlias: process.env.UMBRACO__PROJECTALIAS || require('./package.json').umbraco.projectAlias,
+  apiKey: process.env.UMBRACO__APIKEY || require('./package.json').umbraco.apiKey
 })
-
-const apiKey = process.env.UMBRACO__APIKEY || require('./package.json').umbraco.apiKey;
-if (apiKey) {
-  client.setAPIKey(apiKey);
-}
 
 const getByUrl = async (cache: Object, path: string) => {
   const content = cache[path];
   if (content)
     return content;
-   
+
   return cache[path] = await client.delivery.content.byUrl(path);
 }
 

--- a/src/ApiRequest.ts
+++ b/src/ApiRequest.ts
@@ -36,14 +36,15 @@ export class ApiRequest<R = any> {
       headers: {}
     }
 
-    if(this.endpoint.source === EndpointSource.ContentManagement) {
-      if(this.client.getAPIKey() === null) {
+    if (this.endpoint.source === EndpointSource.ContentManagement) {
+      if (!this.client.options.apiKey) {
         throw new Error("API Key is missing")
       }
-
-      headers["api-key"] = `${this.client.getAPIKey()}`
     }
 
+    if (this.client.options.apiKey) {
+      headers['api-key'] = this.client.options.apiKey
+    }
 
     const options = this.endpoint.options
     log("options", options)

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -3,8 +3,9 @@ import {Endpoint} from "./Endpoint";
 import {ApiRequest} from "./ApiRequest";
 
 export interface ClientOptions {
-    projectAlias: string
-    language?: string
+  projectAlias: string
+  language?: string
+  apiKey?: string
 }
 
 
@@ -13,91 +14,93 @@ export interface ClientOptions {
  */
 export class Client {
 
-    private _apiKey: string|null = null
+  constructor(public readonly options: ClientOptions) {
 
-    constructor(public readonly options: ClientOptions) {
+  }
 
-    }
+  /**
+   * Get Delivery client for fetching content and media from CDN
+   */
+  public readonly delivery = new DeliveryClient(this)
 
-    /**
-     * Get Delivery client for fetching content and media from CDN
-     */
-    public readonly delivery = new DeliveryClient(this)
-
-    /**
-     * Get Manager Client for managing content on Umbraco headless
-     */
-    public readonly management = new ManagementClient(this)
+  /**
+   * Get Manager Client for managing content on Umbraco headless
+   */
+  public readonly management = new ManagementClient(this)
 
 
-    /**
-     * Makes request from and [Endpoint]
-     */
-    public makeRequest = async <R extends any>(endpoint: Endpoint<R>, data?: any): Promise<R> => {
+  /**
+   * Makes request from and [Endpoint]
+   */
+  public makeRequest = async <R extends any>(endpoint: Endpoint<R>, data?: any): Promise<R> => {
 
 
-        const response = await new ApiRequest<R>(this, endpoint, data).promise()
-        const items = this.getEmbeddedData(response)
-        const pageData = this.getPagedData(response)
-        
+    const response = await new ApiRequest<R>(this, endpoint, data).promise()
+    const items = this.getEmbeddedData(response)
+    const pageData = this.getPagedData(response)
 
-        if(pageData) {
-            return {
-                ...pageData,
-                items
-            }
-        } else if (!pageData && items) {
-            return items
-        } else {
-            return response
-        }
-        
 
-        
+    if(pageData) {
+      return {
+        ...pageData,
+        items
+      }
+    } else if (!pageData && items) {
+      return items
+    } else {
+      return response
     }
 
 
-    /**
-     * Sets the API to be used.
-     * @param apikey API Key
-     */
-    public setAPIKey = (apikey: string) => {
-        this._apiKey = apikey
+
+  }
+
+
+  /**
+   * Sets the API to be used.
+   * @param apikey API Key
+   * @deprecated Use `apiKey` on the options instead
+   */
+  public setAPIKey = (apikey: string) => {
+    this.options.apiKey = apikey
+  }
+
+  /**
+   * @deprecated Use `apiKey` on the options instead
+   */
+  public getAPIKey = () => this.options.apiKey
+
+  private getEmbeddedData = (response: any) => {
+    if(response.hasOwnProperty('_embedded')) {
+      const keys = Object.keys(response._embedded)
+      const keyCount = keys.length
+      if(keyCount === 1) {
+        const key = keys[0]
+        return response._embedded[key]
+      }
     }
 
-    public getAPIKey = () => this._apiKey
+    return null
+  }
 
-    private getEmbeddedData = (response: any) => {
-        if(response.hasOwnProperty('_embedded')) {
-            const keys = Object.keys(response._embedded)
-            const keyCount = keys.length
-            if(keyCount === 1) {
-                const key = keys[0]
-                return response._embedded[key]
-            }
-        }
+  private getPagedData = (response: any) => {
+    const lookForProps = ["_totalItems", "_totalPages", "_page", "_pageSize"]
+    const keys = Object.keys(response)
 
-        return null
+    for(let i=0;i<lookForProps.length;i++) {
+      const needle = lookForProps[i]
+      if (keys.indexOf(needle) === -1) return null
     }
 
-    private getPagedData = (response: any) => {
-        const lookForProps = ["_totalItems", "_totalPages", "_page", "_pageSize"]
-        const keys = Object.keys(response)
+    const object: any = {}
+    lookForProps.forEach(key => {
+      object[key.replace(/^_/, '')] = response[key]
+    })
 
-        for(let i=0;i<lookForProps.length;i++) {
-            const needle = lookForProps[i]
-            if (keys.indexOf(needle) === -1) return null
-        }
-
-        const object: any = {}
-        lookForProps.forEach(key => {
-            object[key.replace(/^_/, '')] = response[key]
-        })
-
-        return object
+    return object
 
 
 
-    }
+  }
 
 }


### PR DESCRIPTION
Since you most likely won't change the API Key on an existing `Client` object, calling `client.setAPIKey()` seems a bit weird.

So instead of having to call `client.setAPIKey()`, you can now pass the API Key it as an argument to `Client` e.g.

```ts
const client = new Client({
  projectAlias: 'my-project',
  apiKey: 'api-key'
})
```

I've also marked `client.setAPIKey()` as deprecated