### PR TITLE
Fixes parameters not being added to querystring

### DIFF
--- a/samples/koa/package-lock.json
+++ b/samples/koa/package-lock.json
@@ -191,8 +191,7 @@
       "requires": {
         "axios": "^0.19.0",
         "debug": "^4.1.1",
-        "form-data": "^2.5.1",
-        "node-fetch": "^2.6.0"
+        "form-data": "^2.5.1"
       },
       "dependencies": {
         "@types/form-data": {

--- a/src/RequestOptions/CultureOptions.ts
+++ b/src/RequestOptions/CultureOptions.ts
@@ -1,3 +1,3 @@
 export interface CultureOptions {
-    culture: string
+    culture?: string
 }

--- a/src/RequestOptions/DepthOptions.ts
+++ b/src/RequestOptions/DepthOptions.ts
@@ -1,3 +1,3 @@
 export interface DepthOptions {
-    depth?: string
+    depth?: number
 }

--- a/src/RequestOptions/PageOptions.ts
+++ b/src/RequestOptions/PageOptions.ts
@@ -1,4 +1,4 @@
 export interface PageOptions {
-    page?: string
-    pageSize?: string
+    page?: number
+    pageSize?: number
 }


### PR DESCRIPTION
When specifying parameters like `page`, `pageSize` and `depth` they were not being added to the querystring.

This PR fixes that.

I've also update the parameter types since they were specified as `string` even tho they are numbers. Culture is also marked as optional since it's not a required argument

fixes #12 