### PR TITLE
Fix generated type definitions

### DIFF
--- a/etc/headless-client.api.md
+++ b/etc/headless-client.api.md
@@ -93,6 +93,10 @@ export interface Content {
     // (undocumented)
     _url: string;
     // (undocumented)
+    _urls: {
+        [culture: string]: string;
+    };
+    // (undocumented)
     _writerName: string;
 }
 
@@ -766,8 +770,8 @@ export class ManagementClient {
         byAlias: (alias: string) => Promise<ContentTypeBase>;
     };
     get forms(): {
-        all: () => Promise<import("../../Responses").Form[]>;
-        byId: (id: string) => Promise<import("../../Responses").Form>;
+        all: () => Promise<Form[]>;
+        byId: (id: string) => Promise<Form>;
         submitEntry: (formId: string, data: object) => Promise<any>;
     };
     get language(): {
@@ -779,8 +783,8 @@ export class ManagementClient {
     };
     readonly media: MediaManagementClient;
     get mediaType(): {
-        all: () => Promise<import("../../Responses").MediaTypeContentManager[]>;
-        byAlias: (alias: string) => Promise<import("../../Responses").MediaTypeContentManager>;
+        all: () => Promise<MediaTypeContentManager[]>;
+        byAlias: (alias: string) => Promise<MediaTypeContentManager>;
     };
     readonly member: MemberManagementClient;
     get memberGroup(): {
@@ -793,15 +797,15 @@ export class ManagementClient {
         byAlias: <R_1 extends ContentMemberTypeType>(alias: string) => Promise<R_1>;
     };
     get relation(): {
-        byId: (id: string) => Promise<import("../../Responses").ContentRelationType>;
-        byAlias: (alias: string) => Promise<import("../../Responses").ContentRelationType[]>;
-        byChild: (id: string) => Promise<import("../../Responses").ContentRelationType[]>;
-        byParent: (id: string) => Promise<import("../../Responses").ContentRelationType[]>;
-        create: (data: any) => Promise<import("../../Responses").ContentRelationType>;
-        delete: (id: string) => Promise<import("../../Responses").ContentRelationType>;
+        byId: (id: string) => Promise<ContentRelationType>;
+        byAlias: (alias: string) => Promise<ContentRelationType[]>;
+        byChild: (id: string) => Promise<ContentRelationType[]>;
+        byParent: (id: string) => Promise<ContentRelationType[]>;
+        create: (data: any) => Promise<ContentRelationType>;
+        delete: (id: string) => Promise<ContentRelationType>;
     };
     get relationType(): {
-        byAlias: (alias: string) => Promise<import("../../Responses").ContentRelationTypeType>;
+        byAlias: (alias: string) => Promise<ContentRelationTypeType>;
     };
 }
 

--- a/samples/vue/package-lock.json
+++ b/samples/vue/package-lock.json
@@ -1417,7 +1417,6 @@
       "version": "file:../../dist",
       "requires": {
         "axios": "^0.19.0",
-        "debug": "^4.1.1",
         "form-data": "^2.5.1"
       },
       "dependencies": {

--- a/samples/vue/src/views/UmbracoPage.vue
+++ b/samples/vue/src/views/UmbracoPage.vue
@@ -22,7 +22,6 @@ export default Vue.extend({
     try {
       content = await client.delivery.content.byUrl(to.path)
     } catch (e) {
-      console.log(e)
       content = { contentTypeAlias: 'notFound', name: 'Not Found' }
     }
 
@@ -35,7 +34,6 @@ export default Vue.extend({
     try {
       this.content = await client.delivery.content.byUrl(to.path)
     } catch (e) {
-      console.log(e)
       this.content = { contentTypeAlias: 'notFound', name: 'Not Found' }
     }
     next()

--- a/src/Clients/Management/ManagementClient.ts
+++ b/src/Clients/Management/ManagementClient.ts
@@ -10,7 +10,11 @@ import {
   ContentMemberGroupType,
   ContentMemberTypeType,
   ContentTypeBase,
-  CreateContentLanguageType
+  ContentRelationType,
+  ContentRelationTypeType,
+  CreateContentLanguageType,
+  MediaTypeContentManager,
+  Form
 } from '../../Responses'
 
 /**
@@ -78,7 +82,7 @@ export class ManagementClient {
        * Find content type by alias
        * @param alias Alias for the content type
        */
-      byAlias: async (alias: string) => this.makeRequest(Endpoints.management.contentType.byAlias(alias))
+      byAlias: async (alias: string) : Promise<ContentTypeBase> => this.makeRequest(Endpoints.management.contentType.byAlias(alias))
     }
   }
 
@@ -90,13 +94,13 @@ export class ManagementClient {
       /**
        * Fetch all media types
        */
-      all: async () => this.makeRequest(Endpoints.management.mediaType.all()),
+      all: async () : Promise<MediaTypeContentManager[]> => this.makeRequest(Endpoints.management.mediaType.all()),
 
       /**
        * Find media type by alias
        * @param alias Alias of the media type querying for
        */
-      byAlias: async (alias: string) => this.makeRequest(Endpoints.management.mediaType.byAlias(alias))
+      byAlias: async (alias: string) : Promise<MediaTypeContentManager> => this.makeRequest(Endpoints.management.mediaType.byAlias(alias))
     }
   }
 
@@ -147,37 +151,37 @@ export class ManagementClient {
        * Find relation by id
        * @param id GUID part of an Umbraco UDI
        */
-      byId: async (id: string) => this.makeRequest(Endpoints.management.relation.byId(id)),
+      byId: async (id: string) : Promise<ContentRelationType> => this.makeRequest(Endpoints.management.relation.byId(id)),
 
       /**
        * Find relation by alias
        * @param alias Alias of the relation querying for
        */
-      byAlias: async (alias: string) => this.makeRequest(Endpoints.management.relation.byAlias(alias)),
+      byAlias: async (alias: string) : Promise<ContentRelationType[]> => this.makeRequest(Endpoints.management.relation.byAlias(alias)),
 
       /**
        * Fetch child for relation with id
        * @param id GUID part of an Umbraco UDI
        */
-      byChild: async (id: string) => this.makeRequest(Endpoints.management.relation.byChild(id)),
+      byChild: async (id: string) : Promise<ContentRelationType[]> => this.makeRequest(Endpoints.management.relation.byChild(id)),
 
       /**
        * Fetch parent for relation with id
        * @param id GUID part of an Umbraco UDI
        */
-      byParent: async (id: string) => this.makeRequest(Endpoints.management.relation.byParent(id)),
+      byParent: async (id: string) : Promise<ContentRelationType[]> => this.makeRequest(Endpoints.management.relation.byParent(id)),
 
       /**
        * Create a relation
        * @param data Data for creating relation object
        */
-      create: async (data: any) => this.makeRequest(Endpoints.management.relation.create(), data),
+      create: async (data: any) : Promise<ContentRelationType> => this.makeRequest(Endpoints.management.relation.create(), data),
 
       /**
        * Delete relation with id
        * @param id GUID part of an Umbraco UDI
        */
-      delete: async (id: string) => this.makeRequest(Endpoints.management.relation.delete(id))
+      delete: async (id: string) : Promise<ContentRelationType> => this.makeRequest(Endpoints.management.relation.delete(id))
     }
   }
 
@@ -190,7 +194,7 @@ export class ManagementClient {
        * Fetch relation type by alias
        * @param alias Alias for the relation type queryed for
        */
-      byAlias: async (alias: string) => this.makeRequest(Endpoints.management.relationType.byAlias(alias))
+      byAlias: async (alias: string) : Promise<ContentRelationTypeType> => this.makeRequest(Endpoints.management.relationType.byAlias(alias))
     }
   }
 
@@ -245,12 +249,12 @@ export class ManagementClient {
       /**
        * Fetch all forms
        */
-      all: async () => this.makeRequest(Endpoints.management.forms.all()),
+      all: async () : Promise<Form[]> => this.makeRequest(Endpoints.management.forms.all()),
 
       /**
        * Get form by id
        */
-      byId: async (id: string) => this.makeRequest(Endpoints.management.forms.byId(id)),
+      byId: async (id: string) : Promise<Form> => this.makeRequest(Endpoints.management.forms.byId(id)),
 
       /**
        * Submit a new form entry


### PR DESCRIPTION
Fixed the wrong paths in the generated type definitions, this should fix errors when using the client with TypeScript.

Also removed `console.log` from the vue sample since the production build doesn't allow it