### PR TITLE
Add support for proxying calls through a different url

### DIFF
--- a/etc/headless-client.api.md
+++ b/etc/headless-client.api.md
@@ -39,16 +39,16 @@ export class AuthenticationClient {
 
 // @public
 export class Client {
-    constructor(options: ClientOptions);
+    constructor(options: ClientOptions | ProxyOptions);
     readonly authentication: AuthenticationClient;
     readonly delivery: DeliveryClient;
     // @deprecated (undocumented)
     getAPIKey: () => string | undefined;
     // @internal
-    makeRequest: <R extends any>(endpoint: Endpoint<R, any>, data?: any) => Promise<R>;
+    makeRequest: <R extends any>(endpoint: Endpoint<R>, data?: any) => Promise<R>;
     readonly management: ManagementClient;
     // (undocumented)
-    readonly options: ClientOptions;
+    readonly options: ClientOptions | ProxyOptions;
     // @deprecated
     setAPIKey: (apikey: string) => void;
 }
@@ -574,15 +574,13 @@ export interface DepthOptions {
 // Warning: (ae-internal-missing-underscore) The name "Endpoint" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export class Endpoint<R = any, Options = any> {
-    constructor(source: EndpointSource, path: string, urlParams: any, method: 'get' | 'GET' | 'post' | 'POST' | 'put' | 'PUT' | 'delete' | 'DELETE', options?: Options | undefined);
+export class Endpoint<R = any> {
+    constructor(source: EndpointSource, path: string, urlParams: any, method: 'get' | 'GET' | 'post' | 'POST' | 'put' | 'PUT' | 'delete' | 'DELETE', options?: DepthOptions | PageOptions | HyperlinksOption | ContentTypeOptions | CultureOptions | ContentDeliveryFilterOptions | undefined);
     getPath: () => string;
-    // (undocumented)
-    static getURLAddress: (endpoint: Endpoint<any, any>) => string;
     // (undocumented)
     readonly method: 'get' | 'GET' | 'post' | 'POST' | 'put' | 'PUT' | 'delete' | 'DELETE';
     // (undocumented)
-    readonly options?: Options | undefined;
+    readonly options?: DepthOptions | PageOptions | HyperlinksOption | ContentTypeOptions | CultureOptions | ContentDeliveryFilterOptions | undefined;
     // (undocumented)
     readonly path: string;
     // (undocumented)
@@ -959,6 +957,13 @@ export interface PropertyMediaType {
     sortOrder: number;
     // (undocumented)
     validation: any;
+}
+
+// @public
+export interface ProxyOptions {
+    apiProxyUrl: string;
+    cdnProxyUrl: string;
+    language?: string;
 }
 
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -28,10 +28,32 @@ export interface ClientOptions {
 }
 
 /**
+ * Proxy options
+ * @public
+ */
+export interface ProxyOptions {
+  /**
+   * A custom url for the Content Delivery endpoint.
+   */
+  cdnProxyUrl: string
+  /**
+   * A custom url for the Content Management endpoint.
+   */
+  apiProxyUrl: string
+  /**
+   * The default culture sent with all requests to the Content Delivery API, this can be overwritten per function
+   */
+  language?: string
+}
+
+/**
  * Entry class for accessing the Content Delivery and Content Management APIs.
  * @public
  *
  * @example
+ *
+ * To get started you need create a new instance of the `Client` passing {@link ClientOptions}.
+ *
  * ```typescript
  * import { Client } from '@umbraco/headless-client'
  *
@@ -41,13 +63,27 @@ export interface ClientOptions {
  *  language: '<iso-code>',
  * })
  * ```
+ *
+ * You might want to proxy your request through a server to hide the project alias and the api key,
+ * this can be done by creating a new instance of the `Client` class passing in {@link ProxyOptions}.
+ *
+ * ```typescript
+ * import { Client } from '@umbraco/headless-client'
+ *
+ * const client = new Client({
+ *  apiProxyUrl: '<proxy-url>',
+ *  cdnProxyUrl: '<proxy-url>',
+ *  language: '<iso-code>',
+ * })
+ * ```
+ *
  */
 export class Client {
   /**
    * Constructs a new instance of the `Client` class with the given options.
-   * @param options - The options. See {@link ClientOptions}
+   * @param options - The options. See {@link ClientOptions} or {@link ProxyOptions}.
    */
-  constructor (public readonly options: ClientOptions) {
+  constructor (public readonly options: ClientOptions | ProxyOptions) {
 
   }
 
@@ -99,13 +135,23 @@ export class Client {
    * @deprecated Use `apiKey` in the constructor options instead.
    */
   public setAPIKey = (apikey: string) => {
-    this.options.apiKey = apikey
+    if('apiKey' in this.options) {
+      this.options.apiKey = apikey
+    } else {
+      throw Error('Cannot set apiKey on ProxyOptions')
+    }
   }
 
   /**
    * @deprecated Use `options.apiKey` instead.
    */
-  public getAPIKey = () => this.options.apiKey
+  public getAPIKey = () => {
+    if('apiKey' in this.options) {
+      return this.options.apiKey
+    } else {
+      throw Error('Cannot set apiKey on ProxyOptions')
+    }
+  }
 
   private readonly getEmbeddedData = (response: any) => {
     if (Object.prototype.hasOwnProperty.call(response, '_embedded')) {

--- a/src/Clients/AuthenticationClient.ts
+++ b/src/Clients/AuthenticationClient.ts
@@ -1,4 +1,4 @@
-import { Client } from '../Client'
+import { Client, ClientOptions } from '../Client'
 import { ApiRequest } from '../ApiRequest'
 import { Endpoints } from '../Endpoints'
 import { OAUthResponse } from '../Responses'
@@ -44,7 +44,10 @@ export class AuthenticationClient {
     data.append('username', username)
     data.append('password', password)
 
-    const options = { projectAlias: this.client.options.projectAlias }
+    const options = { projectAlias: '' }
+    if ('projectAlias' in this.client.options) {
+      options.projectAlias = this.client.options.projectAlias
+    }
 
     return new ApiRequest<OAUthResponse>(options, Endpoints.authentication.member(), data).promise()
   }
@@ -61,7 +64,10 @@ export class AuthenticationClient {
     data.append('username', username)
     data.append('password', password)
 
-    const options = { projectAlias: this.client.options.projectAlias }
+    const options = { projectAlias: '' }
+    if ('projectAlias' in this.client.options) {
+      options.projectAlias = this.client.options.projectAlias
+    }
 
     return new ApiRequest<OAUthResponse>(options, Endpoints.authentication.user(), data).promise()
   }

--- a/src/Endpoint.ts
+++ b/src/Endpoint.ts
@@ -1,3 +1,12 @@
+import {
+  ContentDeliveryFilterOptions,
+  ContentTypeOptions,
+  CultureOptions,
+  DepthOptions,
+  HyperlinksOption,
+  PageOptions
+} from './RequestOptions'
+
 /** @internal */
 export enum EndpointSource {
   CDN,
@@ -5,12 +14,14 @@ export enum EndpointSource {
   ContentManagement
 }
 
+type Options = ContentDeliveryFilterOptions | ContentTypeOptions | CultureOptions | DepthOptions | HyperlinksOption | PageOptions
+
 /**
  * This class describes how and endpoint might will look,
  * it's not possible to change value
  * @internal
  */
-export class Endpoint<R = any, Options = any> {
+export class Endpoint<R = any> {
   constructor (
     public readonly source: EndpointSource,
     public readonly path: string,
@@ -38,57 +49,35 @@ export class Endpoint<R = any, Options = any> {
       path = path.replace(regEx, value)
     })
 
-    return path
-  }
-
-  static getURLAddress = (endpoint: Endpoint) => {
-    let url = 'https://{API_TYPE}.umbraco.io' + endpoint.getPath()
-
     const params = new URLSearchParams()
 
-    if (endpoint.options) {
-      if (typeof endpoint.options.pageSize === 'number') {
-        params.append('pageSize', endpoint.options.pageSize)
+    if (this.options) {
+      if ('pageSize' in this.options && typeof this.options.pageSize === 'number') {
+        params.append('pageSize', this.options.pageSize.toString())
       }
-      if (typeof endpoint.options.page === 'number') {
-        params.append('page', endpoint.options.page)
+      if ('page' in this.options && typeof this.options.page === 'number') {
+        params.append('page', this.options.page.toString())
       }
-      if (typeof endpoint.options.depth === 'number') {
-        params.append('depth', endpoint.options.depth)
+      if ('depth' in this.options && typeof this.options.depth === 'number') {
+        params.append('depth', this.options.depth.toString())
       }
-      if (typeof endpoint.options.hyperlinks === 'boolean') {
-        params.append('hyperlinks', endpoint.options.hyperlinks)
+      if ('hyperlinks' in this.options && typeof this.options.hyperlinks === 'boolean') {
+        params.append('hyperlinks', this.options.hyperlinks ? 'true' : 'false')
       }
-      if (typeof endpoint.options.contentType === 'string') {
-        params.append('contentType', endpoint.options.contentType)
+      if ('contentType' in this.options && typeof this.options.contentType === 'string') {
+        params.append('contentType', this.options.contentType)
       }
-      if (typeof endpoint.options.culture === 'string') {
-        params.append('culture', endpoint.options.culture)
+      if ('culture' in this.options && typeof this.options.culture === 'string') {
+        params.append('culture', this.options.culture)
       }
     }
 
     const queryString = params.toString()
 
     if (queryString) {
-      url += `${url.includes('?') ? '&' : '?'}${queryString}`
+      path += `${path.includes('?') ? '&' : '?'}${queryString}`
     }
 
-    let apiType: string
-    switch (endpoint.source) {
-      case EndpointSource.CDN:
-        apiType = 'cdn'
-        break
-
-      case EndpointSource.ContentManagement:
-        apiType = 'api'
-        break
-      default:
-        apiType = 'cdn'
-        break
-    }
-
-    url = url.replace('{API_TYPE}', apiType)
-
-    return url
+    return path
   }
 }

--- a/src/Endpoints.ts
+++ b/src/Endpoints.ts
@@ -68,7 +68,7 @@ export const Endpoints = {
       children: <R extends ContentManagementContent>(id: string, options?: APIContentChildrenOptions) => new Endpoint<PagedResponse<R>>(EndpointSource.ContentManagement, '/content/{id}/children', { id }, 'get', options),
       create: <R extends ContentManagementContent>() => new Endpoint<R>(EndpointSource.ContentManagement, '/content', {}, 'post'),
       publish: <R extends ContentManagementContent>(id: string, options?: APIContentPublishOptions) => {
-        return new Endpoint<R>(EndpointSource.ContentManagement, '/content/{id}/publish', { id }, 'put', options) as Endpoint<R, APIContentPublishOptions>
+        return new Endpoint<R>(EndpointSource.ContentManagement, '/content/{id}/publish', { id }, 'put', options)
       },
       unPublish: <R extends ContentManagementContent>(id: string, options?: APIContentUnpublishOptions) => new Endpoint<R>(EndpointSource.ContentManagement, '/content/{id}/unpublish', { id }, 'put', options),
       update: <R extends ContentManagementContent>(id: string) => new Endpoint<R>(EndpointSource.ContentManagement, '/content/{id}', { id }, 'put'),


### PR DESCRIPTION
Added support for creating the client with proxy urls instead of a project alias.

If you are using the library in a client side application, you will still be able to use this library and be able to avoid exposing the project alias and api key by proxying the requests through a server.

To setup the client for proxying it can be instantiated with an `apiProxyUrl` and `cdnProxyUrl` instead.

```typescript
import { Client } from '@umbraco/headless-client'

const client = new Client({
  apiProxyUrl: '<proxy-url>',
  cdnProxyUrl: '<proxy-url>',
  language: '<iso-code>',
})
```