### PR TITLE
Add preview argument to Client to easy switch api endpoint

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,7 +31,9 @@ import {Client} from '@umbraco/headless-client'
 
 const client = new Client({
   projectAlias: 'your-project-alias',
-  apiKey: 'your-api-key'
+  apiKey: 'your-api-key',
+  language: 'iso-code', // can be overwritten per method
+  preview: true // true/false if the preview API should be used
 })
 
 export default client

--- a/etc/headless-client.api.md
+++ b/etc/headless-client.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import { AxiosResponse } from 'axios';
-import FormData from 'form-data';
+import { default as FormData_2 } from 'form-data';
 
 // @public
 export type APIContentChildrenOptions = PageOptions;
@@ -45,7 +45,7 @@ export class Client {
     // @deprecated (undocumented)
     getAPIKey: () => string | undefined;
     // @internal
-    makeRequest: <R extends any>(endpoint: Endpoint<R>, data?: any) => Promise<R>;
+    makeRequest: <R extends unknown>(endpoint: Endpoint<R>, data?: any) => Promise<R>;
     readonly management: ManagementClient;
     // (undocumented)
     readonly options: ClientOptions | ProxyOptions;
@@ -63,6 +63,7 @@ export interface ClientOptions {
     }): string | undefined;
     apiKey?: string;
     language?: string;
+    preview?: boolean;
     projectAlias: string;
 }
 
@@ -206,12 +207,12 @@ export class ContentManagementClient {
     constructor(client: Client);
     byId<T extends ContentManagementContent>(id: string): Promise<T | undefined>;
     children<T extends ContentManagementContent>(id: string, options?: APIContentChildrenOptions): Promise<PagedResponse<T> | undefined>;
-    create<T extends ContentManagementContent>(body: ContentManagementContentRequest | FormData): Promise<T>;
+    create<T extends ContentManagementContent>(body: ContentManagementContentRequest | FormData_2): Promise<T>;
     delete<T extends ContentManagementContent>(id: string): Promise<ContentManagementContent | undefined>;
     publish<T extends ContentManagementContent>(id: string, options?: APIContentPublishOptions): Promise<T | undefined>;
     root<T extends ContentManagementContent>(): Promise<T[]>;
     unPublish<T extends ContentManagementContent>(id: string, options?: APIContentUnpublishOptions): Promise<T | undefined>;
-    update<T extends ContentManagementContent>(id: string, body: ContentManagementContentRequest | FormData): Promise<T | undefined>;
+    update<T extends ContentManagementContent>(id: string, body: ContentManagementContentRequest | FormData_2): Promise<T | undefined>;
 }
 
 // @public (undocumented)
@@ -855,10 +856,10 @@ export class MediaManagementClient {
     constructor(client: Client);
     byId<T extends ContentManagementMedia>(id: string): Promise<T | undefined>;
     children<T extends ContentManagementMedia>(id: string, options?: APIMediaChildrenOptions): Promise<PagedResponse<T> | undefined>;
-    create<T extends ContentManagementMedia>(body: ContentManagementMediaRequest | FormData): Promise<ContentManagementMedia>;
+    create<T extends ContentManagementMedia>(body: ContentManagementMediaRequest | FormData_2): Promise<ContentManagementMedia>;
     delete<T extends ContentManagementMedia>(id: string): Promise<ContentManagementMedia | undefined>;
     root<T extends ContentManagementMedia>(): Promise<T[]>;
-    update<T extends ContentManagementMedia>(id: string, body: ContentManagementMediaRequest | FormData): Promise<ContentManagementMedia | undefined>;
+    update<T extends ContentManagementMedia>(id: string, body: ContentManagementMediaRequest | FormData_2): Promise<ContentManagementMedia | undefined>;
 }
 
 // @public (undocumented)
@@ -896,14 +897,14 @@ export class MemberManagementClient {
     addToGroup(username: string, groupName: string): Promise<undefined>;
     byUsername<R extends ContentManagementMember>(username: string): Promise<R | undefined>;
     changePassword(username: string, currentPassword: string, newPassword: string): Promise<any>;
-    create<R extends ContentManagementMember>(data: ContentManagementMemberRequest | FormData): Promise<R>;
+    create<R extends ContentManagementMember>(data: ContentManagementMemberRequest | FormData_2): Promise<R>;
     createResetPasswordToken<R extends MemberResetPasswordToken>(username: string): Promise<R | undefined>;
     delete(username: string): Promise<any>;
     removeFromGroup(username: string, groupName: string): Promise<undefined>;
     // @deprecated
     removeGroup(username: string, group: string): Promise<void>;
     resetPassword<R extends ContentManagementMember>(username: string, token: string, newPassword: string): Promise<R | undefined>;
-    update<R extends ContentManagementMember>(username: string, data: ContentManagementMemberRequest | FormData): Promise<R | undefined>;
+    update<R extends ContentManagementMember>(username: string, data: ContentManagementMemberRequest | FormData_2): Promise<R | undefined>;
 }
 
 // @public (undocumented)

--- a/samples/vue/src/client.ts
+++ b/samples/vue/src/client.ts
@@ -2,6 +2,7 @@ import { Client } from '@umbraco/headless-client'
 
 const client = new Client({
   projectAlias: process.env.VUE_APP_UMBRACO__PROJECTALIAS!,
+  apiKey: process.env.VUE_APP_UMBRACO__APIKEY,
   language: 'en-US'
 })
 

--- a/samples/vue/vue.config.js
+++ b/samples/vue/vue.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   css: {
     sourceMap: true
-  }
+  },
+  lintOnSave: false
 }

--- a/src/ApiRequest.ts
+++ b/src/ApiRequest.ts
@@ -32,16 +32,16 @@ export class ApiRequest<R = any> {
     }
 
     const path = this.endpoint.getPath()
-    let url = `https://cdn.umbraco.io`
+    let url = 'https://cdn.umbraco.io'
 
     if (this.endpoint.source === EndpointSource.ContentManagement) {
       url = 'apiProxyUrl' in this.options
-        ? `${this.options.cdnProxyUrl}`
-        : `https://api.umbraco.io`
-    }
-
-    if ('cdnProxyUrl' in this.options) {
-      url = `${this.options.cdnProxyUrl}`
+        ? this.options.apiProxyUrl
+        : 'https://api.umbraco.io'
+    } else if ('cdnProxyUrl' in this.options) {
+      url = this.options.cdnProxyUrl
+    } else if (this.options.preview) {
+      url = 'https://preview.umbraco.io'
     }
 
     url = url.endsWith('/') ? `${url}${path.substr(1)}` : `${url}${path}`

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -20,6 +20,13 @@ export interface ClientOptions {
    */
   apiKey?: string
   /**
+   * Determines if the {@link DeliveryClient} should call the Preview API or the Content Delivery endpoints.
+   *
+   * @remarks
+   * If true an apiKey must be supplied.
+   */
+  preview?: boolean
+  /**
    * Used to retrieve access tokens for requests to the APIs.
    * @param request - The request that's about to be sent.
    * @returns an oauth token that should be used for this request or undefined if no token should be used.


### PR DESCRIPTION
If the Client is constructed with `preview: true` the preview endpoint is used.

```typescript
const client = new Client({
  projectAlias: 'your-project-alias',
  apiKey: 'your-api-key',
  language: 'iso-code',
  preview: true
})
```